### PR TITLE
fix: remove thianyong-hub/devils from invalid-repo-log — repo has valid shim files

### DIFF
--- a/invalid-repo-log.txt
+++ b/invalid-repo-log.txt
@@ -237,7 +237,6 @@ yzksk/extrabotany
 luizgabriels5915/ghast
 evo11211/wobot
 notruri/meteor-client
-thianyong-hub/devils
 rhencloud/meteor-client-cn
 zsm0rgen/6b6taddon
 icenoteblock/legacy


### PR DESCRIPTION
## Summary
Removes 	hianyong-hub/devils from invalid-repo-log.txt so the scanner can re-evaluate it.

## Why it was marked invalid
DEVILS uses a multi-module Gradle layout (devils-addon, devils-game, devils-shared) with the main entrypoint class inside the devils-addon submodule. The scanner likely couldn't locate the entrypoint Java file at the expected path.

## What changed since then
Root-level shim files have been added so the scanner can discover and parse the addon:

| File | Path | Purpose |
|------|------|---------|
| fabric.mod.json | src/main/resources/fabric.mod.json | Entrypoints: com.devils.addon.DevilsAddon (meteor) + com.devils.addon.CrashGuard (preLaunch) |
| DevilsAddon.java | src/main/java/com/devils/addon/DevilsAddon.java | Extends MeteorAddon, registers 20+ modules and 3 commands |
| build.gradle.kts | Root | Configures the base plugin |
| gradle.properties | Root | minecraft_version=1.21.11 |

## Verification
- abric.mod.json id is devils-addon (not ddon-template) ✅
- DevilsAddon.java at correct path matching entrypoint com.devils.addon.DevilsAddon ✅
- Extends MeteorAddon ✅
- Features detected: AntiWasp, AutoAnvilRename, AutoCraft, AutoCev, AutoLogin, AutoPearl, AutoWasp, ClipModules, DiscordRPC, JoinWatcher, LavaBucket, MaceSpoof, NukerPlus, Ping, SpearSpoof, SyncHub, TnTBomber, HighwayBuilder, ModAutoUpdater, StashMover ✅
- gradle.properties at root with minecraft_version=1.21.11 ✅
- Topics include meteor-addon ✅

The scanner should now successfully parse the repo and add it to ddons.json.